### PR TITLE
Add CLI flags

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -36,6 +36,13 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Returns true if {@code flag} exists.
+     */
+    public boolean hasFlag(Flag flag) {
+        return argMultimap.containsKey(flag);
+    }
+
+    /**
      * Returns the last value of {@code prefix}.
      */
     public Optional<String> getValue(Prefix prefix) {

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -47,6 +47,16 @@ public class ArgumentTokenizer {
     private static List<PrefixPosition> findPrefixPositions(String argsString, Prefix prefix) {
         List<PrefixPosition> positions = new ArrayList<>();
 
+        // Handle case for Flag
+        if (prefix instanceof Flag) {
+            Flag flag = (Flag) prefix;
+            int flagPosition = findFlagPosition(argsString, flag.toString());
+            PrefixPosition extendedFlag = new PrefixPosition(flag, flagPosition);
+            positions.add(extendedFlag);
+            return positions;
+        }
+
+
         int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), 0);
         while (prefixPosition != -1) {
             PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
@@ -73,6 +83,15 @@ public class ArgumentTokenizer {
         int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
         return prefixIndex == -1 ? -1
                 : prefixIndex + 1; // +1 as offset for whitespace
+    }
+
+    /**
+     * Returns the index of the first occurrence of {@code Flag} in
+     * {@code argsString} starting from index {@code fromIndex}. Returns -1 if no
+     * such occurrence can be found.
+     */
+    private static int findFlagPosition(String argString, String flag) {
+        return argString.indexOf(flag);
     }
 
     /**
@@ -112,11 +131,16 @@ public class ArgumentTokenizer {
     /**
      * Returns the trimmed value of the argument in the arguments string specified by {@code currentPrefixPosition}.
      * The end position of the value is determined by {@code nextPrefixPosition}.
+     * If current prefix is a flag, return empty string.
      */
     private static String extractArgumentValue(String argsString,
                                         PrefixPosition currentPrefixPosition,
                                         PrefixPosition nextPrefixPosition) {
         Prefix prefix = currentPrefixPosition.getPrefix();
+
+        if (prefix instanceof Flag) {
+            return "";
+        }
 
         int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());

--- a/src/main/java/seedu/address/logic/parser/Flag.java
+++ b/src/main/java/seedu/address/logic/parser/Flag.java
@@ -1,0 +1,11 @@
+package seedu.address.logic.parser;
+
+/**
+ * A flag that modifies the behaviour of a command, represented as a prefix with no arguments.
+ * E.g. '-a' in 'list -a'
+ */
+public class Flag extends Prefix {
+    public Flag(String flag) {
+        super(flag);
+    }
+}


### PR DESCRIPTION
Flag is implemented as a no argument prefix. It's meant to be something like a boolean argument. 

For example, if you want to add the ability to exit without saving, you can try to make a command like:

'exit --nosave'

Instead of creating a new `Command`, just do the following:

1. Add your flag format to `CliSyntax` class, e.g. `public static final Flag EXITFLAG_NOSAVE = new Flag("--nosave")`
2. Modify the respective command parser class to use  `ArgumentTokenizer.tokenize` and `ArgumentMultimap.hasFlag` to check
if the flag exists in the argstring
3. Add a boolean attribute to your `Command` class, which you can use to create alternate behaviours